### PR TITLE
Gas optimizations in ChefIncentivesController and MultiFeeDistribution

### DIFF
--- a/contracts/staking/ChefIncentivesController.sol
+++ b/contracts/staking/ChefIncentivesController.sol
@@ -229,15 +229,14 @@ contract ChefIncentivesController is Ownable {
         _updateEmissions();
         _updatePool(pool, totalAllocPoint);
         UserInfo storage user = userInfo[msg.sender][_user];
-        if (user.amount > 0) {
-            uint256 pending =
-                user.amount.mul(pool.accRewardPerShare).div(1e12).sub(
-                    user.rewardDebt
-                );
+        uint256 amount = user.amount;
+        uint256 accRewardPerShare = pool.accRewardPerShare;
+        if (amount > 0) {
+            uint256 pending = amount.mul(accRewardPerShare).div(1e12).sub(user.rewardDebt);
             _mint(_user, pending);
         }
         user.amount = _balance;
-        user.rewardDebt = _balance.mul(pool.accRewardPerShare).div(1e12);
+        user.rewardDebt = _balance.mul(accRewardPerShare).div(1e12);
         pool.totalSupply = _totalSupply;
         if (pool.onwardIncentives != IOnwardIncentivesController(0)) {
             pool.onwardIncentives.handleAction(msg.sender, _user, _balance, _totalSupply);

--- a/contracts/staking/ChefIncentivesController.sol
+++ b/contracts/staking/ChefIncentivesController.sol
@@ -190,13 +190,12 @@ contract ChefIncentivesController is Ownable {
         uint256 totalAP = totalAllocPoint;
         uint256 length = registeredTokens.length;
         for (uint256 i = 0; i < length; ++i) {
-            _updatePool(registeredTokens[i], totalAP);
+            _updatePool(poolInfo[registeredTokens[i]], totalAP);
         }
     }
 
     // Update reward variables of the given pool to be up-to-date.
-    function _updatePool(address _token, uint256 _totalAllocPoint) internal {
-        PoolInfo storage pool = poolInfo[_token];
+    function _updatePool(PoolInfo storage pool, uint256 _totalAllocPoint) internal {
         if (block.timestamp <= pool.lastRewardTime) {
             return;
         }
@@ -228,7 +227,7 @@ contract ChefIncentivesController is Ownable {
         PoolInfo storage pool = poolInfo[msg.sender];
         require(pool.lastRewardTime > 0);
         _updateEmissions();
-        _updatePool(msg.sender, totalAllocPoint);
+        _updatePool(pool, totalAllocPoint);
         UserInfo storage user = userInfo[msg.sender][_user];
         if (user.amount > 0) {
             uint256 pending =
@@ -238,7 +237,7 @@ contract ChefIncentivesController is Ownable {
             _mint(_user, pending);
         }
         user.amount = _balance;
-        user.rewardDebt = user.amount.mul(pool.accRewardPerShare).div(1e12);
+        user.rewardDebt = _balance.mul(pool.accRewardPerShare).div(1e12);
         pool.totalSupply = _totalSupply;
         if (pool.onwardIncentives != IOnwardIncentivesController(0)) {
             pool.onwardIncentives.handleAction(msg.sender, _user, _balance, _totalSupply);
@@ -255,10 +254,11 @@ contract ChefIncentivesController is Ownable {
         for (uint i = 0; i < _tokens.length; i++) {
             PoolInfo storage pool = poolInfo[_tokens[i]];
             require(pool.lastRewardTime > 0);
-            _updatePool(_tokens[i], _totalAllocPoint);
+            _updatePool(pool, _totalAllocPoint);
             UserInfo storage user = userInfo[_tokens[i]][_user];
-            pending = pending.add(user.amount.mul(pool.accRewardPerShare).div(1e12).sub(user.rewardDebt));
-            user.rewardDebt = user.amount.mul(pool.accRewardPerShare).div(1e12);
+            uint256 rewardDebt = user.amount.mul(pool.accRewardPerShare).div(1e12);
+            pending = pending.add(rewardDebt.sub(user.rewardDebt));
+            user.rewardDebt = rewardDebt;
         }
         _mint(_user, pending);
     }

--- a/contracts/staking/MultiFeeDistribution.sol
+++ b/contracts/staking/MultiFeeDistribution.sol
@@ -121,10 +121,10 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
         address _user,
         address _rewardsToken,
         uint256 _balance,
-        uint256 _rewardPerToken
+        uint256 _currentRewardPerToken
     ) internal view returns (uint256) {
         return _balance.mul(
-            _rewardPerToken.sub(userRewardPerTokenPaid[_user][_rewardsToken])
+            _currentRewardPerToken.sub(userRewardPerTokenPaid[_user][_rewardsToken])
         ).div(1e18).add(rewards[_user][_rewardsToken]);
     }
 
@@ -452,13 +452,13 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
         address token = address(stakingToken);
         uint256 balance;
         Reward storage r = rewardData[token];
-        uint256 rewardPerToken = _rewardPerToken(token, lockedSupply);
-        r.rewardPerTokenStored = rewardPerToken;
+        uint256 rpt = _rewardPerToken(token, lockedSupply);
+        r.rewardPerTokenStored = rpt;
         r.lastUpdateTime = lastTimeRewardApplicable(token);
         if (account != address(0)) {
             // Special case, use the locked balances and supply for stakingReward rewards
-            rewards[account][token] = _earned(account, token, balances[account].locked, rewardPerToken);
-            userRewardPerTokenPaid[account][token] = rewardPerToken;
+            rewards[account][token] = _earned(account, token, balances[account].locked, rpt);
+            userRewardPerTokenPaid[account][token] = rpt;
             balance = balances[account].total;
         }
 
@@ -467,12 +467,12 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
         for (uint i = 1; i < length; i++) {
             token = rewardTokens[i];
             r = rewardData[token];
-            rewardPerToken = _rewardPerToken(token, supply);
-            r.rewardPerTokenStored = rewardPerToken;
+            rpt = _rewardPerToken(token, supply);
+            r.rewardPerTokenStored = rpt;
             r.lastUpdateTime = lastTimeRewardApplicable(token);
             if (account != address(0)) {
-                rewards[account][token] = _earned(account, token, balance, rewardPerToken);
-                userRewardPerTokenPaid[account][token] = rewardPerToken;
+                rewards[account][token] = _earned(account, token, balance, rpt);
+                userRewardPerTokenPaid[account][token] = rpt;
             }
         }
         _;

--- a/contracts/staking/MultiFeeDistribution.sol
+++ b/contracts/staking/MultiFeeDistribution.sol
@@ -231,7 +231,8 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
         uint256 penaltyAmount
     ) {
         Balances storage bal = balances[user];
-        if (bal.earned > 0) {
+        uint256 earned = bal.earned;
+        if (earned > 0) {
             uint256 amountWithoutPenalty;
             uint256 length = userEarnings[user].length;
             for (uint i = 0; i < length; i++) {
@@ -243,9 +244,9 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
                 amountWithoutPenalty = amountWithoutPenalty.add(earnedAmount);
             }
 
-            penaltyAmount = bal.earned.sub(amountWithoutPenalty).div(2);
+            penaltyAmount = earned.sub(amountWithoutPenalty).div(2);
         }
-        amount = bal.unlocked.add(bal.earned).sub(penaltyAmount);
+        amount = bal.unlocked.add(earned).sub(penaltyAmount);
         return (amount, penaltyAmount);
     }
 


### PR DESCRIPTION
These modifications improve gas efficiency within Geist's incentives controller and staking contract, which are two of the most expensive contracts. Mostly I've assigned temporary memory variables to avoid repeated storage reads, and created storage pointers for commonly accessed mappings. I've also done some refactoring in the flow of updateReward and earned.

The repo does not contain tests but I have done my best to verify that the changes made do not affect the functionality in any way. I'm seeing an improvement of around 200,000 gas when calling exit on the staking contract (the most expensive function).