### PR TITLE
Don't mint on all actions, selective reward claims

### DIFF
--- a/contracts/interfaces/IChefIncentivesController.sol
+++ b/contracts/interfaces/IChefIncentivesController.sol
@@ -18,4 +18,6 @@ interface IChefIncentivesController {
 
     function addPool(address _token, uint256 _allocPoint) external;
 
+    function claim(address _user, address[] calldata _tokens) external;
+
 }

--- a/contracts/staking/MultiFeeDistribution.sol
+++ b/contracts/staking/MultiFeeDistribution.sol
@@ -369,12 +369,14 @@ contract MultiFeeDistribution is IMultiFeeDistribution, Ownable {
         for (uint i; i < length; i++) {
             address token = _rewardTokens[i];
             uint256 reward = rewards[msg.sender][token];
-            if (i > 0) {
+            if (token != address(stakingToken)) {
                 // for rewards other than stakingToken, every 24 hours we check if new
                 // rewards were sent to the contract or accrued via aToken interest
                 Reward storage r = rewardData[token];
+                uint256 periodFinish = r.periodFinish;
+                require(periodFinish > 0, "Unknown reward token");
                 uint256 balance = r.balance;
-                if (r.periodFinish < block.timestamp.add(rewardsDuration - 86400)) {
+                if (periodFinish < block.timestamp.add(rewardsDuration - 86400)) {
                     uint256 unseen = IERC20(token).balanceOf(address(this)).sub(balance);
                     if (unseen > 0) {
                         _notifyReward(token, unseen);

--- a/contracts/staking/MultiFeeDistribution.sol
+++ b/contracts/staking/MultiFeeDistribution.sol
@@ -7,7 +7,6 @@ import "../dependencies/openzeppelin/contracts/IERC20.sol";
 import "../dependencies/openzeppelin/contracts/SafeERC20.sol";
 import "../dependencies/openzeppelin/contracts/SafeMath.sol";
 import "../dependencies/openzeppelin/contracts/Ownable.sol";
-import "../dependencies/openzeppelin/contracts/ReentrancyGuard.sol";
 
 
 interface IMintableToken is IERC20 {
@@ -17,7 +16,7 @@ interface IMintableToken is IERC20 {
 
 // Based on Ellipsis EPS Staker
 // https://github.com/ellipsis-finance/ellipsis/blob/master/contracts/EpsStaker.sol
-contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable {
+contract MultiFeeDistribution is IMultiFeeDistribution, Ownable {
 
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
@@ -260,7 +259,7 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
 
     // Stake tokens to receive rewards
     // Locked tokens cannot be withdrawn for lockDuration and are eligible to receive stakingReward rewards
-    function stake(uint256 amount, bool lock) external nonReentrant updateReward(msg.sender) {
+    function stake(uint256 amount, bool lock) external updateReward(msg.sender) {
         require(amount > 0, "Cannot stake 0");
         totalSupply = totalSupply.add(amount);
         Balances storage bal = balances[msg.sender];
@@ -316,7 +315,7 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
     // Withdraw staked tokens
     // First withdraws unlocked tokens, then earned tokens. Withdrawing earned tokens
     // incurs a 50% penalty which is distributed based on locked balances.
-    function withdraw(uint256 amount) public nonReentrant updateReward(msg.sender) {
+    function withdraw(uint256 amount) public updateReward(msg.sender) {
         require(amount > 0, "Cannot withdraw 0");
         Balances storage bal = balances[msg.sender];
         uint256 penaltyAmount;
@@ -363,7 +362,7 @@ contract MultiFeeDistribution is IMultiFeeDistribution, ReentrancyGuard, Ownable
     }
 
     // Claim all pending staking rewards
-    function getReward() public nonReentrant updateReward(msg.sender) {
+    function getReward() public updateReward(msg.sender) {
         uint256 length = rewardTokens.length;
         for (uint i; i < length; i++) {
             address token = rewardTokens[i];


### PR DESCRIPTION
This pull request considerably reduces gas costs by introducing the following changes:

1. In the incentives contract, new tokens are not minted on each call to handleAction. Pending mintable balances are instead tracked in a mapping, and only minted on a call to claim.
2. In the staking contract, it is now possible to call exit without claiming rewards, and to only claim specific rewards.